### PR TITLE
Feature/load xml from string

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,9 @@ gb = GreenButton.load_xml_from_file('PATH/TO/FILE.XML')
 
 # To load from URL:
 gb = GreenButton.load_xml_from_web('https://services.greenbuttondata.org/DataCustodian/espi/1_1/resource/Batch/RetailCustomer/3/UsagePoint')
+
+# To load from string:
+gb = GreenButton.load_xml_from_string(xml_string)
 ```
 
 This code will load the Green Button XML from the given file or URL and parse it into a series of Ruby objects representing the data contained in the file.

--- a/lib/greenbutton.rb
+++ b/lib/greenbutton.rb
@@ -18,7 +18,12 @@ module GreenButton
     xml_file.remove_namespaces!
     Parser.new(xml_file)
   end
-	  
+
+  def self.load_xml_from_string(string)
+    xml_file = Nokogiri::XML.parse(string)
+    xml_file.remove_namespaces!
+    Parser.new(xml_file)
+  end
 
 	class Parser
 		attr_accessor :doc, :usage_points

--- a/lib/greenbutton/gb_classes.rb
+++ b/lib/greenbutton/gb_classes.rb
@@ -1,7 +1,6 @@
 module GreenButtonClasses
   require_relative 'helpers.rb'
   require 'nokogiri'
-  require 'pry'
   
   Rule = Helper::Rule
   RULES = {


### PR DESCRIPTION
### Context
As a software engineer developing an application using the greenbutton gem, I had the need to parse xml from a string and not from a file or a url.

### Work
- Added a method to load xml from string
- Updated the documentation according to this new feature